### PR TITLE
UPDATE機能のServiceテストとDBテストを実装する。

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,25 @@ curl --location --request DELETE 'http://localhost:8080/employees/delete/70' \
 ### テスト成功
 
 <img width="600" alt="スクリーンショット 2024-02-19 20 20 28" src="https://github.com/ADA-ad/employee/assets/152973671/6c0e1f2e-0f90-4b7b-8ba2-a0d8c069e95e">
+
+### UPDATE処理のServiceテスト
+#### 実装したテスト内容
+
+- 存在する従業員の名前と年齢と住所を更新すること
+- 既に存在する従業員情報を重複更新すること
+
+### 二つ全てのテスト成功
+
+<img width="600" alt="スクリーンショット 2024-02-21 19 27 30" src="https://github.com/ADA-ad/employee/assets/152973671/081e9be2-3023-4583-8a66-0fc08d6bc2dd">
+<img width="600" alt="スクリーンショット 2024-02-21 19 29 10" src="https://github.com/ADA-ad/employee/assets/152973671/4ea84d3a-96f5-49b6-8682-b9f58a0cdaf8">
+
+### UPDATE処理のDBテスト
+#### 実装したテスト内容
+
+- 存在する従業員を更新すること
+- 存在しないIDで従業員を更新処理した場合は更新されないこと
+
+### 二つ全てのテスト成功
+
+<img width="600" alt="スクリーンショット 2024-02-21 19 30 17" src="https://github.com/ADA-ad/employee/assets/152973671/f5b6f312-361f-406f-888d-506d8c646e2a">
+<img width="600" alt="スクリーンショット 2024-02-21 19 30 45" src="https://github.com/ADA-ad/employee/assets/152973671/62657aa3-ad57-4ce8-9372-38182af428aa">

--- a/src/test/java/com/kadai10/employee/mapper/EmployeeMapperTest.java
+++ b/src/test/java/com/kadai10/employee/mapper/EmployeeMapperTest.java
@@ -95,4 +95,24 @@ class EmployeeMapperTest {
         employeeMapper.insert(employee);
     }
 
+    //UPDATE機能のDBテスト
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @ExpectedDataSet(value = "datasets/updateEmployeesTest.yml")
+    @Transactional
+    public void 存在する従業員を更新すること() {
+        Employee employee = new Employee(2, "花房 清", 25, "岡山県岡山市5-2-3");
+        employeeMapper.updateEmployee(employee);
+    }
+
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @ExpectedDataSet(value = "datasets/employees.yml")
+    @Transactional
+    public void 存在しないIDで従業員を更新処理した場合は更新されないこと() {
+        Employee employee = new Employee(100, "花房 清", 25, "岡山県岡山市5-2-3");
+        employeeMapper.updateEmployee(employee);
+    }
+
+
 }

--- a/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
@@ -110,5 +110,25 @@ public class EmployeeServiceTest {
         });
     }
 
-    
+
+    //UPDATE機能のテスト(PATCH)
+    @Test
+    public void 存在する従業員の名前と年齢と住所を更新すること() {
+        doReturn(Optional.of(new Employee(2, "花房 清", 25, "岡山県岡山市5-2-3"))).when(employeeMapper).findById(2);
+        Employee actual = employeeService.updateEmployee(2, new EmployeeUpdateRequest("花房 清", 25, "岡山県岡山市5-2-3"));
+        Employee employee = new Employee(2, "花房 清", 25, "岡山県岡山市5-2-3");
+        verify(employeeMapper).findById(2);
+        verify(employeeMapper).updateEmployee(employee);
+    }
+
+    @Test
+    public void 既に存在する従業員情報を重複更新すること() {
+        when(employeeMapper.findByNameAndAddress("佐藤 陽葵", "静岡県伊豆市1-2-3")).thenReturn(List.of(new Employee(2, "佐藤 陽葵", 20, "静岡県伊豆市1-2-3")));
+        assertThrows(EmployeeAlreadyExistsException.class, () -> {
+            employeeService.insert("佐藤 陽葵", 20,"静岡県伊豆市1-2-3");
+        });
+    }
+
+
+
 }

--- a/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
@@ -122,7 +122,7 @@ public class EmployeeServiceTest {
     }
 
     @Test
-    public void 既に存在する従業員情報を重複更新すること() {
+    public void 既に存在する名前と住所の従業員情報に更新するとエラーが返されること() {
         when(employeeMapper.findByNameAndAddress("佐藤 陽葵", "静岡県伊豆市1-2-3")).thenReturn(List.of(new Employee(2, "佐藤 陽葵", 20, "静岡県伊豆市1-2-3")));
         assertThrows(EmployeeAlreadyExistsException.class, () -> {
             employeeService.insert("佐藤 陽葵", 20,"静岡県伊豆市1-2-3");


### PR DESCRIPTION
### UPDATE処理のServiceテスト
#### 実装したテスト内容

- 存在する従業員の名前と年齢と住所を更新すること
- 既に存在する従業員情報を重複更新すること

### 二つ全てのテスト成功

<img width="600" alt="スクリーンショット 2024-02-21 19 27 30" src="https://github.com/ADA-ad/employee/assets/152973671/081e9be2-3023-4583-8a66-0fc08d6bc2dd">
<img width="600" alt="スクリーンショット 2024-02-21 19 29 10" src="https://github.com/ADA-ad/employee/assets/152973671/4ea84d3a-96f5-49b6-8682-b9f58a0cdaf8">

### UPDATE処理のDBテスト
#### 実装したテスト内容

- 存在する従業員を更新すること
- 存在しないIDで従業員を更新処理した場合は更新されないこと

### 二つ全てのテスト成功

<img width="600" alt="スクリーンショット 2024-02-21 19 30 17" src="https://github.com/ADA-ad/employee/assets/152973671/f5b6f312-361f-406f-888d-506d8c646e2a">
<img width="600" alt="スクリーンショット 2024-02-21 19 30 45" src="https://github.com/ADA-ad/employee/assets/152973671/62657aa3-ad57-4ce8-9372-38182af428aa">
