### PR TITLE
DELETE機能のServiceテストとDBテストを実装する。

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,25 @@ curl --location --request DELETE 'http://localhost:8080/employees/delete/70' \
 
 <img width="600" alt="スクリーンショット 2024-02-21 19 30 17" src="https://github.com/ADA-ad/employee/assets/152973671/f5b6f312-361f-406f-888d-506d8c646e2a">
 <img width="600" alt="スクリーンショット 2024-02-21 19 30 45" src="https://github.com/ADA-ad/employee/assets/152973671/62657aa3-ad57-4ce8-9372-38182af428aa">
+
+### DELETE処理のServiceテスト
+#### 実装したテスト内容
+
+- 存在するIDを指定して削除できること
+- 存在しないIDを指定した時にエラーが返ること
+
+### 二つ全てのテスト成功
+<img width="600" alt="スクリーンショット 2024-02-26 22 13 13" src="https://github.com/ADA-ad/employee/assets/152973671/e2b7479c-68e3-46ed-a320-5bc1ee3e0e82">
+<img width="600" alt="スクリーンショット 2024-02-26 22 14 33" src="https://github.com/ADA-ad/employee/assets/152973671/17c7989d-9678-4db3-9c5e-83450a19b1a1">
+
+
+### DELETE処理のDBテスト
+#### 実装したテスト内容
+
+- 存在する従業員情報を削除すること
+- 存在しないIDの従業員情報を指定した場合は削除されないこと
+
+### 二つ全てのテスト成功
+
+<img width="600" alt="スクリーンショット 2024-02-26 22 15 07" src="https://github.com/ADA-ad/employee/assets/152973671/f80e0f96-cb96-475f-a3ea-ea3f00e100d1">
+<img width="600" alt="スクリーンショット 2024-02-26 22 15 38" src="https://github.com/ADA-ad/employee/assets/152973671/c482f289-18c4-4704-b3a3-a42ec23d7f68">

--- a/src/test/java/com/kadai10/employee/mapper/EmployeeMapperTest.java
+++ b/src/test/java/com/kadai10/employee/mapper/EmployeeMapperTest.java
@@ -113,6 +113,20 @@ class EmployeeMapperTest {
         Employee employee = new Employee(100, "花房 清", 25, "岡山県岡山市5-2-3");
         employeeMapper.updateEmployee(employee);
     }
+    //DELETE機能のDBテスト
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @ExpectedDataSet(value = "datasets/deleteEmployeesTest.yml")
+    @Transactional
+    public void 存在する従業員情報を削除すること() {
+        employeeMapper.deleteEmployee(1);
+    }
 
-
+    @Test
+    @DataSet(value = "datasets/employees.yml")
+    @ExpectedDataSet(value = "datasets/employees.yml")
+    @Transactional
+    public void 存在しないIDの従業員情報を指定した場合は削除されないこと() {
+        employeeMapper.deleteEmployee(100);
+    }
 }

--- a/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
@@ -128,7 +128,23 @@ public class EmployeeServiceTest {
             employeeService.insert("佐藤 陽葵", 20,"静岡県伊豆市1-2-3");
         });
     }
+    //DELETE機能のテスト
+    @Test
+    public void 存在するIDを指定して削除できること() {
+        doReturn(Optional.of(new Employee("鈴木 碧", 16, "東京都品川区1-1-1"))).when(employeeMapper).findById(1);
+        employeeService.deleteEmployee(1);
+        verify(employeeMapper).findById(1);
+        verify(employeeMapper).deleteEmployee(1);
+    }
 
+    @Test
+    public void 存在しないIDを指定した時にエラーが返ること() {
+        doReturn(Optional.empty()).when(employeeMapper).findById(100);
+        assertThrows(EmployeeNotFoundException.class, () -> {
+            employeeService.deleteEmployee(100);
+        }, "指定された従業員が見つかりません");
+        verify(employeeMapper).findById(100);
+    }
 
 
 }

--- a/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
+++ b/src/test/java/com/kadai10/employee/service/EmployeeServiceTest.java
@@ -128,6 +128,7 @@ public class EmployeeServiceTest {
             employeeService.insert("佐藤 陽葵", 20,"静岡県伊豆市1-2-3");
         });
     }
+
     //DELETE機能のテスト
     @Test
     public void 存在するIDを指定して削除できること() {


### PR DESCRIPTION
### DELETE処理のServiceテスト
#### 実装したテスト内容

- 存在するIDを指定して削除できること
- 存在しないIDを指定した時にエラーが返ること

### 二つ全てのテスト成功
<img width="600" alt="スクリーンショット 2024-02-26 22 13 13" src="https://github.com/ADA-ad/employee/assets/152973671/e2b7479c-68e3-46ed-a320-5bc1ee3e0e82">
<img width="600" alt="スクリーンショット 2024-02-26 22 14 33" src="https://github.com/ADA-ad/employee/assets/152973671/17c7989d-9678-4db3-9c5e-83450a19b1a1">


### DELETE処理のDBテスト
#### 実装したテスト内容

- 存在する従業員情報を削除すること
- 存在しないIDの従業員情報を指定した場合は削除されないこと

### 二つ全てのテスト成功

<img width="600" alt="スクリーンショット 2024-02-26 22 15 07" src="https://github.com/ADA-ad/employee/assets/152973671/f80e0f96-cb96-475f-a3ea-ea3f00e100d1">
<img width="600" alt="スクリーンショット 2024-02-26 22 15 38" src="https://github.com/ADA-ad/employee/assets/152973671/c482f289-18c4-4704-b3a3-a42ec23d7f68">
